### PR TITLE
Improve clip time constraints

### DIFF
--- a/src/layers/layer.js
+++ b/src/layers/layer.js
@@ -54,7 +54,7 @@ function layer(state) {
 		var animatedProp;
 		var timeCap = property.getTimeCap();
 		if(layerData.ip + state.timeOffset > 0 || layerData.op + state.timeOffset + parentWorkAreaOffset < timeCap) {
-			if(targets.getTargetByNameAndProperty(name,'scaleX') || targets.getTargetByNameAndProperty(name,'scaleY')) {
+			if(targets.getTargetByNameAndProperty(name,'scaleY')) {
 				name += naming.TIME_NAME;
 				var timeGroup = node.createNode('group', name);
 				node.nestChild(timeGroup, group);
@@ -62,12 +62,16 @@ function layer(state) {
 			}
 			var scaleX = (node.getAttribute(group, 'android:scaleX') || 1) * 100;
 			var scaleY = (node.getAttribute(group, 'android:scaleY') || 1) * 100;
-			if(layerData.ip + state.timeOffset > 0) {
-				animatedProp = property.createAnimatedProperty(name, 'scaleX', [{s:[0,0,100],e:[scaleX,scaleY,100],t:0},{t:0}], layerData.ip + state.timeOffset);
-				targets.addTarget(animatedProp);
-				
+			var clipStart = layerData.ip + state.timeOffset > 0;
+			var clipEnd = layerData.op + state.timeOffset + parentWorkAreaOffset < timeCap;
+			if(clipStart) {
+				node.addAttribute(group,'android:scaleY', 0);
 			}
-			if(layerData.op + state.timeOffset + parentWorkAreaOffset < timeCap) {
+			if(clipStart || clipEnd) {
+				animatedProp = property.createAnimatedProperty(name, 'scaleY', [{s:[0,0,100],e:[scaleX,scaleY,100],t:0},{t:0}], layerData.ip + state.timeOffset);
+				targets.addTarget(animatedProp);
+			}
+			if(clipEnd) {
 				animatedProp = property.createAnimatedProperty(name, 'scaleY', [{s:[scaleX,scaleY,100],e:[0,0,100],t:0},{t:0}], layerData.op + state.timeOffset + parentWorkAreaOffset);
 				targets.addTarget(animatedProp);
 			}


### PR DESCRIPTION
Fixes issues where layers clipped by time constraints were not properly set and reset.

On all Android versions, layers clipped by time constraints were not initially set to be hidden. This caused the image to appear before the animation started.

On Android API 24 and lower, values are not reset when animations are replayed. This resulted in layers only showing on the first run of the animation since things were hidden with the scaleY property, but shown again with the scaleX property. This PR resolves this by only using scaleY to clip time limits.

Here is a sample AE file that reproduces the issue when exported to avd. [bugsample.aep.zip](https://github.com/bodymovin/bodymovin-to-avd/files/2569163/bugsample.aep.zip)

The expected animation is for the red rectangle to appear some time into the animation, move across the screen and hide. The blue rectangle shows the full duration of the animation.

Here is a gif illustrating the issue on Android API 24
![bugsample_api24](https://user-images.githubusercontent.com/8862324/48310689-a9435100-e547-11e8-8700-9c8bbe91e7a6.gif)

And on API 27
![bugsample_api27](https://user-images.githubusercontent.com/8862324/48310691-ad6f6e80-e547-11e8-94b1-cd1b6f00d343.gif)


